### PR TITLE
Auto scroll to top - QOL

### DIFF
--- a/Games/GameHandler.js
+++ b/Games/GameHandler.js
@@ -1729,6 +1729,8 @@ function handleSearchInput() {
   }
   dVanillaRecyclerView.setData(formattedArrayDataRef);
   dVanillaRecyclerView.calculateSize();
+
+  classDiv.scrollTop = 0;
 }
 searchCancelButton.addEventListener("click", function () {
   searchInput.value = "";


### PR DESCRIPTION
This automatically scrolls to the top of the class-list div to prevent you from being stuck super far down if the recycler is hiding the elements and not causing the actual DOM element's size to change.

Currently, if you scroll very far down in the classlist, and then search, you will remain all the way in the bottom even though its filtering the items further up, this fixes that problem by just putting you at the top.

Small QOL change.