### PR TITLE
Slow workflow fix

### DIFF
--- a/.github/workflows/pull_request_message.yml
+++ b/.github/workflows/pull_request_message.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Greet Pull Request
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
I don't see the need for fetch-depth being 0 when the git commit history has become this large, I just made a pull request and it took almost 9 minutes, where 8 of them were spent just checking out the repository where it had to download almost 4gb of git history, no point if fetching all of that, can be changed to 2 more if the history is actually needed, I don't see anywhere in the workflow where it might though

Would make pull requests get checked much faster :)